### PR TITLE
Be sure that the destination directory exists

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -225,6 +225,7 @@ class Local extends AbstractAdapter
     {
         $location = $this->prefix($path);
         $destination = $this->prefix($newpath);
+        $this->ensureDirectory(dirname($destination));
 
         return copy($location, $destination);
     }


### PR DESCRIPTION
The importIncomingFile method of the concrete5 file Importer always [fallback to write](https://github.com/concrete5/concrete5-5.7.0/blob/284fb8ede436aebf180367eb0e74dfca84db2e95/web/concrete/src/File/Importer.php#L182-L189) because copy fails. And it fails because the destination directory doesn't exist, so let's be sure that the destination dir exists.
